### PR TITLE
Support configurable gRPC server address via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ for await (const event of stream) {
 await client.close();
 ```
 
+## Configuration
+
+| Environment variable | Description | Default |
+| --- | --- | --- |
+| `WHATSAPP_BUSINESS_ENDPOINT` | gRPC server address (host:port) | `whatsapp-business-grpc.spectrum.photon.codes:443` |
+
 ## Development
 
 ```bash

--- a/src/transport/grpc-client.ts
+++ b/src/transport/grpc-client.ts
@@ -53,7 +53,9 @@ export interface GrpcClients {
 // Options
 // ---------------------------------------------------------------------------
 
-const SERVER_ADDRESS = "whatsapp-business-grpc.spectrum.photon.codes:443";
+const SERVER_ADDRESS =
+  process.env.WHATSAPP_BUSINESS_ENDPOINT ??
+  "whatsapp-business-grpc.spectrum.photon.codes:443";
 
 export interface GrpcClientOptions {
   /** Credentials for the WhatsApp Business API. */


### PR DESCRIPTION
## Summary

- Make the gRPC server address configurable via the `WHATSAPP_BUSINESS_ENDPOINT` environment variable
- Falls back to the existing default (`whatsapp-business-grpc.spectrum.photon.codes:443`) when the env var is not set
- Update README with a Configuration section documenting the new env var

## Usage

Set the environment variable to point to a custom gRPC endpoint:

```bash
export WHATSAPP_BUSINESS_ENDPOINT="my-custom-server:443"
```

Or omit it to use the default Spectrum gateway.

## Changes

- **`src/transport/grpc-client.ts`**: Read `SERVER_ADDRESS` from `process.env.WHATSAPP_BUSINESS_ENDPOINT` with nullish coalescing fallback to the default address
- **`README.md`**: Add Configuration section with environment variable documentation

## Test plan

- [ ] Verify SDK connects to the default endpoint when `WHATSAPP_BUSINESS_ENDPOINT` is not set
- [ ] Verify SDK connects to a custom endpoint when `WHATSAPP_BUSINESS_ENDPOINT` is set
- [ ] Confirm README renders correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the WhatsApp Business gRPC endpoint via environment variable, with a default fallback value.

* **Documentation**
  * Added Configuration section to README documenting the new environment variable and its default endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->