### PR TITLE
docs: update Meta app setup for new Meta UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Use this SDK directly with credentials from a Meta WhatsApp app you own. You'll 
 
 5. **Configure the webhook.** In your app: **Use cases** → **API Setup** → scroll to **Step 3** → **Configure webhooks** ([docs](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/set-up-webhooks)):
    - **Callback URL:** `https://whatsapp-business.spectrum.photon.codes/webhook`
-   - **Verify Token:** any value — Meta requires you to set one, but Photon's shared endpoint doesn't check it (so `hello` works as well as anything else)
+   - **Verify Token:** any value. Meta's spec normally requires the endpoint to validate this token and return `hub.challenge` only on match, but Photon's shared endpoint always returns the challenge regardless, so anything works (e.g., `hello`).
    - Click **Verify and Save**, then toggle the `messages` field to **Subscribed**.
 
 6. Pass the three credentials to `createClient` — done.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Use this SDK directly with credentials from a Meta WhatsApp app you own. You'll 
 
 5. **Configure the webhook.** In your app: **Use cases** → **API Setup** → scroll to **Step 3** → **Configure webhooks** ([docs](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/set-up-webhooks)):
    - **Callback URL:** `https://whatsapp-business.spectrum.photon.codes/webhook`
-   - **Verify Token:** anything (the handshake always returns the challenge)
+   - **Verify Token:** any value — Meta requires you to set one, but Photon's shared endpoint doesn't check it (so `hello` works as well as anything else)
    - Click **Verify and Save**, then toggle the `messages` field to **Subscribed**.
 
 6. Pass the three credentials to `createClient` — done.

--- a/README.md
+++ b/README.md
@@ -39,19 +39,27 @@ Sign up at **[app.photon.codes](https://app.photon.codes)**, toggle WhatsApp on 
 
 ### 2. Bring your own Meta app
 
-Use this SDK directly with credentials from a Meta WhatsApp app you own.
+Use this SDK directly with credentials from a Meta WhatsApp app you own. You'll need three values: `phoneNumberId`, `accessToken`, and `appSecret`.
 
-1. Create an app at **[developers.facebook.com](https://developers.facebook.com/apps)** and add the **WhatsApp** product. ([docs](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started))
-2. Under **WhatsApp → API Setup**, copy your `phone_number_id`.
-3. Generate a **permanent access token** via a System User — the token shown on the API Setup page expires in 24 hours, so don't use that one in production:
-   1. Open **[Business Manager → Business Settings → System users](https://business.facebook.com/settings/system-users)**, click **Add**, and create a user with **Admin** role.
-   2. **Assign assets** → pick your app (enable *Manage app*) and your WhatsApp account (enable *Manage WhatsApp Business Accounts*).
-   3. Click **Generate new token**, select your app, and check the `whatsapp_business_messaging`, `whatsapp_business_management`, and `business_management` scopes. Copy the token — it never expires. ([docs](https://developers.facebook.com/docs/whatsapp/business-management-api/get-started))
-4. Under **App Settings → Basic**, copy your `app_secret`.
-5. Under **WhatsApp → Configuration**, set the webhook ([docs](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/set-up-webhooks)):
+1. **Create the app.** At **[developers.facebook.com/apps](https://developers.facebook.com/apps)**, click **Create app**. Name the app, enter your email, toggle **"Connect with customers through WhatsApp"**, and click **Next**. Create a business portfolio (name + contact info), **Next**, then **Create app**. Your app dashboard opens automatically.
+
+2. **Get your Phone Number ID.** In the dashboard, click **Use cases** → **Customize** under "Add use cases" → **API Setup** in the second sidebar. Under **From**, click **Generate new phone number** to create a test sender. The **Phone Number ID** appears directly below — copy it. To send test messages to yourself, open the **To** dropdown → **Manage phone number list** → add your own number.
+
+   Ignore the blue **Generate Access Token** button on this page — that token expires in 24 hours. Step 3 generates a permanent one.
+
+3. **Generate a permanent Access Token via a System User.** At **[Business Manager → System Users](https://business.facebook.com/settings/system-users)**:
+   1. Click **Add**, name the user, set the role to **Admin**, then **Create system user**.
+   2. Click the **three dots** next to "Revoke Tokens" → **Assign Assets** → toggle **Full Control** on for your app → **Save**.
+   3. In the left sidebar under **Accounts**, click **WhatsApp accounts** → select your WhatsApp Business Account → **Assign People** → pick the system user → toggle **Full Control** → **Save**.
+   4. Back on the system user, click **Generate token**. Select your app, check `whatsapp_business_messaging`, `whatsapp_business_management`, and `business_management`, set expiration to **Never**, and copy the token — this is your `accessToken`.
+
+4. **Get your App Secret.** **My apps** → your app → **App settings** → **Basic**. Click **Show** next to App Secret and copy it.
+
+5. **Configure the webhook.** In your app: **Use cases** → **API Setup** → scroll to **Step 3** → **Configure webhooks** ([docs](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/set-up-webhooks)):
    - **Callback URL:** `https://whatsapp-business.spectrum.photon.codes/webhook`
-   - **Verify token:** anything (the handshake always returns the challenge)
-   - Subscribe to the `messages` field
+   - **Verify Token:** anything (the handshake always returns the challenge)
+   - Click **Verify and Save**, then toggle the `messages` field to **Subscribed**.
+
 6. Pass the three credentials to `createClient` — done.
 
 The webhook endpoint is free, public, and shared across all developers. You don't register with us, and we never save your `access_token` or `app_secret`.


### PR DESCRIPTION
## Summary
- Rewrites section 2 ("Bring your own Meta app") to match Meta's current Business Suite navigation — previous click-paths referenced pages that have been moved or renamed
- Same overall flow (Phone Number ID → permanent System User token → App Secret → webhook), just with current UI
- Adds an explicit callout in step 2 to skip the API Setup "Generate Access Token" button so users don't ship the 24h temp token in production

## Test plan
- [x] Walked through the new flow end-to-end on a fresh Meta app
- [x] Verified the System User token authenticates against the live API by sending a test message via `client.messages.send` — message delivered
- [ ] Spot-check tone and any internal-link conventions